### PR TITLE
Writable attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.a
 mkmf.log
 .greenbar
+.idea

--- a/lib/lotus/validations.rb
+++ b/lib/lotus/validations.rb
@@ -254,6 +254,14 @@ module Lotus
             @attributes.get(:#{ name })
           end
         }
+
+        if (options.include?(:writable) && options[:writable] == true)
+          class_eval %{
+            def #{ name }=(value)
+              @attributes.set(:#{ name }, value)
+            end
+          }
+        end
       end
 
       private

--- a/lib/lotus/validations/attribute.rb
+++ b/lib/lotus/validations/attribute.rb
@@ -66,6 +66,10 @@ module Lotus
         end
       end
 
+      def value=(value)
+        @value = value
+      end
+
       private
       # Validates presence of the value.
       # This fails with `nil` and "blank" values.

--- a/lib/lotus/validations/attribute_set.rb
+++ b/lib/lotus/validations/attribute_set.rb
@@ -1,5 +1,5 @@
 class AttributeSet
-  VALIDATIONS = [:presence, :acceptance, :format, :inclusion, :exclusion, :confirmation, :size, :type].freeze
+  VALIDATIONS = [:presence, :acceptance, :format, :inclusion, :exclusion, :confirmation, :size, :type, :writable].freeze
 
   def initialize
     @attributes = Hash.new {|h,k| h[k] = {} }

--- a/lib/lotus/validations/attributes.rb
+++ b/lib/lotus/validations/attributes.rb
@@ -18,6 +18,11 @@ module Lotus
         (attr = @attributes[name]) and attr.value
       end
 
+      def set(name, value)
+        attr = @attributes[name]
+        attr.value = value if attr
+      end
+
       def dup
         Utils::Hash.new(to_h).deep_dup
       end

--- a/test/attribute_accessor_test.rb
+++ b/test/attribute_accessor_test.rb
@@ -8,19 +8,19 @@ describe Lotus::Validations do
 
     it 'test attribute write possibility' do
       obj = AttributeAccessorTest.new attr: 5
-      assert_equal 5, obj.attr
+      obj.attr.must_equal 5
 
       obj.attr = 6
-      assert_equal 6, obj.attr
+      obj.attr.must_equal 6
     end
 
     it 'test attribute valid and writable' do
       obj = WritablePresenceValidatorTest.new name: "Roberto"
       assert obj.valid?
-      assert_equal "Roberto", obj.name
+      obj.name.must_equal "Roberto"
 
       obj.name = "Matteo"
-      assert_equal "Matteo", obj.name
+      obj.name.must_equal "Matteo"
     end
 
   end

--- a/test/attribute_accessor_test.rb
+++ b/test/attribute_accessor_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+describe Lotus::Validations do
+  describe 'attribute writer' do
+    it 'test attribute name' do
+      assert AttributeAccessorTest.defined_attribute?(:attr)
+    end
+
+    it 'test attribute write possibility' do
+      obj = AttributeAccessorTest.new attr: 5
+      assert_equal 5, obj.attr
+
+      obj.attr = 6
+      assert_equal 6, obj.attr
+    end
+
+    it 'test attribute valid and writable' do
+      obj = WritablePresenceValidatorTest.new name: "Roberto"
+      assert obj.valid?
+      assert_equal "Roberto", obj.name
+
+      obj.name = "Matteo"
+      assert_equal "Matteo", obj.name
+    end
+
+  end
+end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -47,6 +47,12 @@ class UniquenessAttributeTest
   attribute :attr
 end
 
+class AttributeAccessorTest
+  include Lotus::Validations
+  extend  Lotus::Validations::AttributesIntrospection
+
+  attribute 'attr', writable: true
+end
 class AnotherValidator
   include Lotus::Validations
 
@@ -216,4 +222,10 @@ class EnumerableValidator
   include Lotus::Validations
 
   attribute :name
+end
+
+class WritablePresenceValidatorTest
+  include Lotus::Validations
+
+  attribute :name,  presence: true, writable: true
 end


### PR DESCRIPTION
Modified to add the possibility to have writable attributes. 
Don't know if this agree with the validation project philosophy, but we need this capability in a plain ruby project, just to change an invalid attribute or to set an attribute after validation process.

Thanks
   Roberto