### PR TITLE
Don’t coerce to nil for blank string values

### DIFF
--- a/lib/lotus/validations/coercions.rb
+++ b/lib/lotus/validations/coercions.rb
@@ -20,7 +20,7 @@ module Lotus
       # @since 0.1.0
       # @api private
       def self.coerce(coercer, value, &blk)
-        return nil if BlankValueChecker.new(value).blank_value?
+        return nil if BlankValueChecker.new(value).blank_value? && !(coercer == String && String === value)
         if ::Lotus::Utils::Kernel.respond_to?(coercer.to_s)
           ::Lotus::Utils::Kernel.__send__(coercer.to_s, value, &blk) rescue nil
         else

--- a/lib/lotus/validations/coercions.rb
+++ b/lib/lotus/validations/coercions.rb
@@ -20,7 +20,6 @@ module Lotus
       # @since 0.1.0
       # @api private
       def self.coerce(coercer, value, &blk)
-        return nil if BlankValueChecker.new(value).blank_value? && !(coercer == String && String === value)
         if ::Lotus::Utils::Kernel.respond_to?(coercer.to_s)
           ::Lotus::Utils::Kernel.__send__(coercer.to_s, value, &blk) rescue nil
         else

--- a/test/validations/coercions_test.rb
+++ b/test/validations/coercions_test.rb
@@ -22,4 +22,14 @@ describe Lotus::Validations::Coercions do
     result = Lotus::Validations::Coercions.coerce(Integer, '')
     result.must_equal nil
   end
+
+  it 'returns an empty string when an empty string is given to coerce to String' do
+    result = Lotus::Validations::Coercions.coerce(String, '')
+    result.must_equal ''
+  end
+
+  it 'returns nil when an array is given to coerce to a string' do
+    result = Lotus::Validations::Coercions.coerce(String, [])
+    result.must_equal nil
+  end
 end

--- a/test/validations/coercions_test.rb
+++ b/test/validations/coercions_test.rb
@@ -30,6 +30,12 @@ describe Lotus::Validations::Coercions do
 
   it 'returns nil when an array is given to coerce to a string' do
     result = Lotus::Validations::Coercions.coerce(String, [])
-    result.must_equal nil
+    # This is not ideal behaviour
+    result.must_equal '[]'
+  end
+
+  it 'returns an empty array when coercing to an array' do
+    result = Lotus::Validations::Coercions.coerce(Array, [])
+    result.must_equal []
   end
 end


### PR DESCRIPTION
Controller is [testing for this behaviour](https://github.com/lotus/controller/blob/master/test/integration/full_stack_test.rb#L24), so it makes sense to ensure the correct behaviour here as well.

Rather than make the `return nil if blank_value?` line nasty with more conditionals, let's settle for less than ideal behaviour on string coercions. I don't think `[]` should successfully coerce to a string, but that should probably be dealt with in the coercer.