### PR TITLE
Ensure whitelisted assignment of attributes doesn't include ruby methods

### DIFF
--- a/lib/lotus/validations/attribute_definer.rb
+++ b/lib/lotus/validations/attribute_definer.rb
@@ -37,6 +37,19 @@ module Lotus
           base.defined_attributes.merge(defined_attributes)
         end
 
+        # Override Ruby's hook for modules.
+        #
+        # @param base [Class] the target class
+        #
+        # @since 0.2.2
+        # @api private
+        #
+        # @see http://www.ruby-doc.org/core/Module.html#method-i-extended
+        def inherited(base)
+          super
+          base.defined_attributes.merge(defined_attributes)
+        end
+
         # Define an attribute
         #
         # @param name [#to_sym] the name of the attribute

--- a/lib/lotus/validations/attribute_definer.rb
+++ b/lib/lotus/validations/attribute_definer.rb
@@ -32,17 +32,9 @@ module Lotus
         # @api private
         #
         # @see http://www.ruby-doc.org/core/Module.html#method-i-extended
-        def self.extended(base)
-          base.class_eval do
-            include Utils::ClassAttribute
-
-            # Lotus::Controller compatibility
-            #
-            # @since 0.2.2
-            # @api private
-            class_attribute :defined_attributes
-            self.defined_attributes = Set.new
-          end
+        def included(base)
+          super
+          base.defined_attributes.merge(defined_attributes)
         end
 
         # Define an attribute
@@ -233,6 +225,10 @@ module Lotus
           validates(name, options)
         end
 
+        def defined_attributes
+          @defined_attributes ||= Set.new
+        end
+
         private
 
         # @since 0.2.2
@@ -243,7 +239,9 @@ module Lotus
           defined_attributes.add(name.to_s)
 
           if options[:confirmation]
-            define_accessor("#{ name }_confirmation", type)
+            confirmation_accessor = "#{ name }_confirmation"
+            define_accessor(confirmation_accessor, type)
+            defined_attributes.add(confirmation_accessor)
           end
         end
 
@@ -325,7 +323,7 @@ module Lotus
         @attributes ||= Utils::Attributes.new
         attributes.to_h.each do |key, value|
           writer = "#{ key }="
-          public_send(writer, value) if respond_to?(writer)
+          public_send(writer, value) if self.class.defined_attributes.include?(key.to_s)
         end
       end
     end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -41,6 +41,20 @@ class UndefinedAttributesValidator
   end
 end
 
+class MethodAssignmentTest
+  include Lotus::Validations
+  attribute :name
+
+  def ==(other)
+    @equal_param = other
+    true
+  end
+
+  def equal_param
+    @equal_param
+  end
+end
+
 class UniquenessAttributeTest
   include Lotus::Validations
   extend  Lotus::Validations::ValidationIntrospection

--- a/test/inheritance_test.rb
+++ b/test/inheritance_test.rb
@@ -24,5 +24,10 @@ describe Lotus::Validations do
       subclass.valid?.must_equal false
       subclass.errors.for(:name).must_include Lotus::Validations::Error.new(:name, :presence, true, nil)
     end
+
+    it "receives attributes from the super class" do
+      subclass = SubclassValidatorTest.new({age: 32, name: 'Luca'})
+      subclass.to_h.must_equal({age: 32, name: 'Luca'})
+    end
   end
 end

--- a/test/initialize_test.rb
+++ b/test/initialize_test.rb
@@ -59,5 +59,10 @@ describe Lotus::Validations do
       validator['a'].must_be_nil
       validator['b'].must_be_nil
     end
+
+    it "doesn't assign to unknown attributes that are methods" do
+      validator = MethodAssignmentTest.new('==' => 1)
+      validator.equal_param.must_be_nil
+    end
   end
 end


### PR DESCRIPTION
This PR whitelists the assignment of attributes to the set of defined attributes (`public_send(writer, value) if self.class.defined_attributes.include?(key.to_s)`), and also fixes a couple of other issues that came up because of this:

- confirmation attributes weren't being added as attributes, now they are.
- defined_attributes has been changed to make inheritance and inclusion work as expected.