### PR TITLE
Flatten nested errors

### DIFF
--- a/lib/lotus/validations/attribute.rb
+++ b/lib/lotus/validations/attribute.rb
@@ -200,8 +200,10 @@ module Lotus
       def nested
         _validate(__method__) do |validator|
           errors = value.validate
-          unless errors.empty?
-            @errors.set @name, errors
+          if errors.any?
+            errors.each do |error|
+              @errors.add "#{@name}.#{error.attribute}", error
+            end
           end
           true
         end

--- a/lib/lotus/validations/attribute.rb
+++ b/lib/lotus/validations/attribute.rb
@@ -202,7 +202,9 @@ module Lotus
           errors = value.validate
           if errors.any?
             errors.each do |error|
-              @errors.add "#{@name}.#{error.attribute}", error
+              namespaced_attribute_name = "#{@name}.#{error.attribute}"
+              new_error = Error.new(namespaced_attribute_name, error.validation, error.expected, error.actual)
+              @errors.add namespaced_attribute_name, new_error
             end
           end
           true

--- a/lib/lotus/validations/attribute.rb
+++ b/lib/lotus/validations/attribute.rb
@@ -200,12 +200,10 @@ module Lotus
       def nested
         _validate(__method__) do |validator|
           errors = value.validate
-          if errors.any?
-            errors.each do |error|
-              namespaced_attribute_name = "#{@name}.#{error.attribute}"
-              new_error = Error.new(namespaced_attribute_name, error.validation, error.expected, error.actual)
-              @errors.add namespaced_attribute_name, new_error
-            end
+          errors.each do |error|
+            namespaced_attribute_name = "#{@name}.#{error.attribute}"
+            new_error = Error.new(namespaced_attribute_name, error.validation, error.expected, error.actual)
+            @errors.add namespaced_attribute_name, new_error
           end
           true
         end

--- a/lib/lotus/validations/attribute.rb
+++ b/lib/lotus/validations/attribute.rb
@@ -201,9 +201,8 @@ module Lotus
         _validate(__method__) do |validator|
           errors = value.validate
           errors.each do |error|
-            namespaced_attribute_name = "#{@name}.#{error.attribute}"
-            new_error = Error.new(namespaced_attribute_name, error.validation, error.expected, error.actual)
-            @errors.add namespaced_attribute_name, new_error
+            new_error = Error.new(error.attribute, error.validation, error.expected, error.actual, @name)
+            @errors.add new_error.attribute, new_error
           end
           true
         end

--- a/lib/lotus/validations/error.rb
+++ b/lib/lotus/validations/error.rb
@@ -56,6 +56,25 @@ module Lotus
           other.expected   == expected   &&
           other.actual     == actual
       end
+
+      # Returns the de-namesapced attribute name
+      #
+      # In cases where the error was pulled up from nested validators,
+      # `attribute` will be a namespaced string with the last element being the
+      # actual attribute name
+      #
+      # @example
+      #   error = Error.new('author.name', :presence, true, nil)
+      #   error.attribute
+      #   => "author.name"
+      #   error.attribute_name
+      #   => "name"
+      #
+      # @api public
+      # @since x.x.x
+      def attribute_name
+        @attribute.to_s.split('.').last
+      end
     end
   end
 end

--- a/lib/lotus/validations/error.rb
+++ b/lib/lotus/validations/error.rb
@@ -9,7 +9,7 @@ module Lotus
       # @return [Symbol] the name of the attribute
       #
       # @since 0.1.0
-      attr_reader :attribute
+      attr_reader :attribute_name
 
       # The name of the validation
       #
@@ -32,6 +32,25 @@ module Lotus
       # @since 0.1.0
       attr_reader :actual
 
+      # Returns the namespaced attribute name
+      #
+      # In cases where the error was pulled up from nested validators,
+      # `attribute` will be a namespaced string containing
+      # parent attribute names separated by a period.
+      #
+      # @example
+      #   error = Error.new(:name, :presence, true, nil, 'author')
+      #   error.attribute
+      #   => "author.name"
+      #   error.attribute_name
+      #   => "name"
+      #
+      # @api public
+      # @since x.x.x
+      def attribute
+        [@namespace, attribute_name].compact.join('.')
+      end
+
       # Initialize a validation error
       #
       # @param attribute [Symbol] the name of the attribute
@@ -41,9 +60,9 @@ module Lotus
       #
       # @since 0.1.0
       # @api private
-      def initialize(attribute, validation, expected, actual)
-        @attribute, @validation, @expected, @actual =
-          attribute, validation, expected, actual
+      def initialize(attribute_name, validation, expected, actual, namespace = nil)
+        @attribute_name, @validation, @expected, @actual, @namespace =
+          attribute_name, validation, expected, actual, namespace
       end
 
       # Check if self equals to `other`
@@ -55,25 +74,6 @@ module Lotus
           other.validation == validation &&
           other.expected   == expected   &&
           other.actual     == actual
-      end
-
-      # Returns the de-namesapced attribute name
-      #
-      # In cases where the error was pulled up from nested validators,
-      # `attribute` will be a namespaced string with the last element being the
-      # actual attribute name
-      #
-      # @example
-      #   error = Error.new('author.name', :presence, true, nil)
-      #   error.attribute
-      #   => "author.name"
-      #   error.attribute_name
-      #   => "name"
-      #
-      # @api public
-      # @since x.x.x
-      def attribute_name
-        @attribute.to_s.split('.').last
       end
     end
   end

--- a/lib/lotus/validations/error.rb
+++ b/lib/lotus/validations/error.rb
@@ -47,9 +47,7 @@ module Lotus
       #
       # @api public
       # @since x.x.x
-      def attribute
-        [@namespace, attribute_name].compact.join('.')
-      end
+      attr_accessor :attribute
 
       # Initialize a validation error
       #
@@ -62,7 +60,8 @@ module Lotus
       # @api private
       def initialize(attribute_name, validation, expected, actual, namespace = nil)
         @attribute_name, @validation, @expected, @actual, @namespace =
-          attribute_name, validation, expected, actual, namespace
+          attribute_name.to_s, validation, expected, actual, namespace
+        @attribute = [@namespace, attribute_name].compact.join('.')
       end
 
       # Check if self equals to `other`

--- a/lib/lotus/validations/error.rb
+++ b/lib/lotus/validations/error.rb
@@ -59,8 +59,11 @@ module Lotus
       # @since 0.1.0
       # @api private
       def initialize(attribute_name, validation, expected, actual, namespace = nil)
-        @attribute_name, @validation, @expected, @actual, @namespace =
-          attribute_name.to_s, validation, expected, actual, namespace
+        @attribute_name = attribute_name.to_s
+        @validation = validation
+        @expected = expected
+        @actual = actual
+        @namespace = namespace
         @attribute = [@namespace, attribute_name].compact.join('.')
       end
 

--- a/lib/lotus/validations/errors.rb
+++ b/lib/lotus/validations/errors.rb
@@ -100,14 +100,6 @@ module Lotus
         end
       end
 
-      # Sets the errors for an attribute to a given object
-      #
-      # @since x.x.x
-      # @api private
-      def set(attribute, errors)
-        @errors[attribute] = errors
-      end
-
       # Return the errors for the given attribute
       #
       # @param attribute [Symbol] the name of the attribute

--- a/lib/lotus/validations/errors.rb
+++ b/lib/lotus/validations/errors.rb
@@ -15,7 +15,7 @@ module Lotus
       # @since 0.1.0
       # @api private
       def initialize
-        @errors = Hash.new {|h,k| h[k] = [] }
+        @errors = Hash.new
       end
 
       # Check if the set is empty
@@ -94,7 +94,10 @@ module Lotus
       #
       # @see Lotus::Validations::Error
       def add(attribute, *errors)
-        @errors[attribute].push(*errors) if errors.any?
+        if errors.any?
+          @errors[attribute] ||= []
+          @errors[attribute].push(*errors)
+        end
       end
 
       # Sets the errors for an attribute to a given object
@@ -111,7 +114,7 @@ module Lotus
       #
       # @since 0.1.0
       def for(attribute)
-        @errors[attribute]
+        @errors.fetch(attribute) { [] }
       end
 
       # Check if the current set of errors equals to the one who belongs to

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -16,5 +16,18 @@ describe Lotus::Validations do
       3.times { @validator.valid? }
       @validator.errors.count.must_equal(2)
     end
+
+    it "doesn't have errors after requesting an attribute that doesn't have errors" do
+      @validator.name = 'Luca'
+      @validator.age = 32
+      @validator.valid?.must_equal(true)
+
+      # Triggers the behaviour of making Errors think it now
+      # has errors
+      @validator.errors.for(:name).must_equal([])
+
+      @validator.errors.any?.must_equal(false)
+      @validator.errors.to_h.must_equal({})
+    end
   end
 end

--- a/test/nested_test.rb
+++ b/test/nested_test.rb
@@ -29,13 +29,21 @@ describe Lotus::Validations do
     it 'is invalid when nested attributes fail validation' do
       validator = @klass.new(name: 'John Smith', address: { city: 'Melbourne' })
       validator.valid?.must_equal(false)
-      line_one_error = validator.errors.for(:address).for(:line_one)
-      line_one_error.must_include(Lotus::Validations::Error.new(:line_one, :presence, true, nil))
+      expected_error = Lotus::Validations::Error.new(:line_one, :presence, true, nil)
+      line_one_errors = validator.errors.for('address.line_one')
+      line_one_errors.must_include(expected_error)
+      validator.errors.to_h.must_equal({
+        'address.line_one' => [Lotus::Validations::Error.new(:line_one, :presence, true, nil)]
+      })
     end
 
     it 'is valid when nested attributes pass validation' do
       validator = @klass.new(name: 'John Smith', address: { line_one: '10 High Street' })
       validator.valid?.must_equal(true)
+      validator.errors.to_h.must_equal({})
+      validator.errors.for('address.line_one').must_equal([])
+      validator.address.errors.for(:line_one).must_equal([])
+      validator.errors.to_h.must_equal({})
     end
   end
 end

--- a/test/nested_test.rb
+++ b/test/nested_test.rb
@@ -29,11 +29,11 @@ describe Lotus::Validations do
     it 'is invalid when nested attributes fail validation' do
       validator = @klass.new(name: 'John Smith', address: { city: 'Melbourne' })
       validator.valid?.must_equal(false)
-      expected_error = Lotus::Validations::Error.new(:line_one, :presence, true, nil)
+      expected_error = Lotus::Validations::Error.new('address.line_one', :presence, true, nil)
       line_one_errors = validator.errors.for('address.line_one')
       line_one_errors.must_include(expected_error)
       validator.errors.to_h.must_equal({
-        'address.line_one' => [Lotus::Validations::Error.new(:line_one, :presence, true, nil)]
+        'address.line_one' => [Lotus::Validations::Error.new('address.line_one', :presence, true, nil)]
       })
     end
 

--- a/test/validations/errors_test.rb
+++ b/test/validations/errors_test.rb
@@ -197,7 +197,7 @@ describe Lotus::Validations::Errors do
   describe 'attribute names' do
     it 'returns the attribute string when not namespaced' do
       error = Lotus::Validations::Error.new(:name, :presence, true, nil)
-      error.attribute_name.must_equal(:name)
+      error.attribute_name.must_equal('name')
       error.attribute.must_equal('name')
     end
 

--- a/test/validations/errors_test.rb
+++ b/test/validations/errors_test.rb
@@ -194,13 +194,17 @@ describe Lotus::Validations::Errors do
     end
   end
 
-  describe '#attribute_name' do
+  describe 'attribute names' do
     it 'returns the attribute string when not namespaced' do
-      Lotus::Validations::Error.new(:name, :presence, true, nil).attribute_name.must_equal('name')
+      error = Lotus::Validations::Error.new(:name, :presence, true, nil)
+      error.attribute_name.must_equal(:name)
+      error.attribute.must_equal('name')
     end
 
     it 'returns the last segment of the attribute name when namespaced' do
-      Lotus::Validations::Error.new('job.author', :presence, true, nil).attribute_name.must_equal('author')
+      error = Lotus::Validations::Error.new('author', :presence, true, nil, :job)
+      error.attribute_name.must_equal('author')
+      error.attribute.must_equal('job.author')
     end
   end
 end

--- a/test/validations/errors_test.rb
+++ b/test/validations/errors_test.rb
@@ -193,5 +193,15 @@ describe Lotus::Validations::Errors do
       deserialized.must_equal(@actual)
     end
   end
+
+  describe '#attribute_name' do
+    it 'returns the attribute string when not namespaced' do
+      Lotus::Validations::Error.new(:name, :presence, true, nil).attribute_name.must_equal('name')
+    end
+
+    it 'returns the last segment of the attribute name when namespaced' do
+      Lotus::Validations::Error.new('job.author', :presence, true, nil).attribute_name.must_equal('author')
+    end
+  end
 end
 


### PR DESCRIPTION
- Fixes an issue where by requesting errors for an attribute (with for) the Errors object would then think it had errors (with .any?)
- Flattens nested errors based on the parent attribute name.
- `#attribute` returns the nested attribute name, `#attribute_name` always returns the de-namespaced attribute name.