### PR TITLE
Refactor attribute definer for entity

### DIFF
--- a/lib/lotus/validations/attribute_definer.rb
+++ b/lib/lotus/validations/attribute_definer.rb
@@ -420,21 +420,15 @@ module Lotus
           @defined_attributes.merge(attributes.map(&:to_s))
         end
 
-        # @since x.x.x
-        # @api private
+        # Override attribute accessors function.
         #
-        # @see Lotus::Model::Entity#attributes
-        def attributes(*attrs)
-          if attrs.any?
-            attrs = Lotus::Utils::Kernel.Array(attrs)
-            attrs.each do |attr|
-              _attribute(attr)
-              attr_accessor(attr) if define_attribute?(attr)
-            end
-            self.attributes.merge attrs
-          else
-            @attributes ||= Set.new
-          end
+        # @since x.x.x
+        # 
+        # @api private
+        # @see Lotus::Model::Entity#define_attr_accessor
+        def define_attr_accessor(attr)
+          _attribute(attr)
+          super
         end
 
         # @since 0.2.3


### PR DESCRIPTION
Since we have now separate method in Entity, that define attribute accessor, we can use it, and not override whole `attributes` function.
That can also lead to bug, because dirty tracking using new approach, while `validation` override whole `attributes`, so `define_attr_accessor` never invoked.