### PR TITLE
Allows attribute `type` to be specified as `Array[Person]`

### DIFF
--- a/lib/lotus/validations/coercions.rb
+++ b/lib/lotus/validations/coercions.rb
@@ -22,6 +22,8 @@ module Lotus
       def self.coerce(coercer, value, &blk)
         if ::Lotus::Utils::Kernel.respond_to?(coercer.to_s)
           ::Lotus::Utils::Kernel.__send__(coercer.to_s, value, &blk) rescue nil
+        elsif coercer.is_a?(Array)
+          value.map { |v| coerce(coercer[0], v) }
         else
           coercer.new(value, &blk)
         end


### PR DESCRIPTION
Opening this PR to start discussion.

I would like to be able to do this:

```ruby
class Person
  attr_reader :name

  def initalize(attributes); 
    @name = attributes.fetch(:name)
  end
end

class MyForm
  include Lotus::Validations

  attribute :people, type: Array[Person]
end

form = MyForm.new(people: [{ name: 'Kris', name: 'Lindsey' }]
form.people.first.name # => 'Kris'
form.people.all? { |p| p.is_a?(Person) } # => true
```

This PR is a quick hack, there are no tests. If you think it is an okay direction - handling a coercer which is a one element Array, as a special case - then I will submit a proper PR with tests.

In theory you could also support something like `type: Array[Person, Fruit, Mineral]` if the collection was not homogeneous but can't see a usecase for this and it would probably be confusing.