### PR TITLE
Added blank_value? to size predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,35 @@ person.email # => "me@example.org"
 person.age   # => raises NoMethodError because `:age` wasn't defined as attribute.
 ```
 
+#### Blank Values
+
+The framework will treat as valid any blank attributes, __without__ `presence`, for both `format` and `size` predicates.
+
+```ruby
+require 'lotus/validations'
+
+class Person
+  include Lotus::Validations
+
+  attribute :name,    type: String, size: 5..45
+  attribute :email,   type: String, size: 20..80, format: /@/
+  attribute :skills,  type: Array,  size: 1..3
+  attribute :keys,    type: Hash,   size: 1..3
+end
+
+Person.new.valid?                             # < true
+Person.new(name: '').valid?                   # < true
+Person.new(email: '@').valid?                 # < true
+Person.new(skills: '').valid?                 # < true
+Person.new(skills: ['ruby', 'lotus']).valid?  # < true
+
+Person.new(skills: []).valid?                 # < false
+Person.new(keys: {}).valid?                   # < false
+Person.new(keys: {a: :b}, skills: []).valid?  # < false
+```
+
+If you want to _disable_ this behaviour, please, refer to [presence](https://github.com/lotus/validations#presence).
+
 ### Validations
 
 If you prefer Lotus::Validations to **only define validations**, but **not attributes**,

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ end
 
 Person.new.valid?                             # < true
 Person.new(name: '').valid?                   # < true
-Person.new(email: '@').valid?                 # < true
 Person.new(skills: '').valid?                 # < true
 Person.new(skills: ['ruby', 'lotus']).valid?  # < true
 

--- a/lib/lotus/validations/attribute.rb
+++ b/lib/lotus/validations/attribute.rb
@@ -171,6 +171,8 @@ module Lotus
       #
       # If the quantity is a Range, the size of the value MUST be included.
       #
+      # If the attribute's value is blank, the size will not be considered
+      #
       # The value is an object which implements `#size`.
       #
       # @raise [ArgumentError] if the defined quantity isn't a Numeric or a
@@ -181,6 +183,8 @@ module Lotus
       # @since 0.2.0
       # @api private
       def size
+        return if blank_value?
+
         _validate(__method__) do |validator|
           case validator
           when Numeric, ->(v) { v.respond_to?(:to_int) }

--- a/lib/lotus/validations/blank_value_checker.rb
+++ b/lib/lotus/validations/blank_value_checker.rb
@@ -38,7 +38,17 @@ module Lotus
       # @since 0.2.2
       # @api private
       def _empty_value?
+        return false if _enumerable?
         (@value.respond_to?(:empty?) and @value.empty?)
+      end
+
+      # Collectable classes should not be considered as blank value
+      # even if it's responds _true_ to its own `empty?` method.
+      #
+      # @since x.x.x
+      # @api private
+      def _enumerable?
+        @value.respond_to?(:each)
       end
     end
   end

--- a/test/composed_validation_test.rb
+++ b/test/composed_validation_test.rb
@@ -40,6 +40,19 @@ describe Lotus::Validations do
 
         validator.valid?.must_equal true
       end
+
+      # Bug https://github.com/lotus/validations/issues/81
+      it 'is valid if included attributes are blank and does not define presence constraint' do
+        validator = ComposedValidationsWithoutPresenceTest.new(email: '', name: '')
+
+        validator.valid?.must_equal true
+      end
+
+      it 'is not valid if included attributes are invalid' do
+        validator = ComposedValidationsWithoutPresenceTest.new(email: 'fo', name: 'o')
+
+        validator.valid?.must_equal false
+      end
     end
 
     describe 'nested composed validations' do

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -106,8 +106,8 @@ end
 class FormatValidatorTest
   include Lotus::Validations
 
-  attribute :name,                 format: /\A[a-zA-Z]+\z/
-  attribute :age,    type: String, format: /\A[0-9]+\z/
+  attribute :name,               format: /\A[a-zA-Z]+\z/
+  attribute :age,  type: String, format: /\A[0-9]+\z/
 end
 
 class InclusionValidatorTest
@@ -185,12 +185,24 @@ module EmailValidations
   attribute :email, presence: true, format: /@/
 end
 
+module EmailValidationsWithoutPresence
+  include Lotus::Validations
+
+  attribute :email, format: /@/
+end
+
 module CommonValidations
   include EmailValidations
 end
 
 class ComposedValidationsTest
   include EmailValidations
+end
+
+class ComposedValidationsWithoutPresenceTest
+  include EmailValidationsWithoutPresence
+
+  attribute :name, size: 8..50
 end
 
 module PasswordValidations

--- a/test/size_validation_test.rb
+++ b/test/size_validation_test.rb
@@ -103,6 +103,22 @@ describe Lotus::Validations do
       end
     end
 
+    # Bug https://github.com/lotus/validations/issues/81
+    it 'is valid if attribute is defined as blank' do
+      validator = SizeValidatorTest.new(password: 'foobarbazqux', ssn: '')
+
+      validator.valid?.must_equal true
+      validator.errors.must_be_empty
+    end
+
+    it 'is not valid if attribute is an empty collection' do
+      validator = SizeValidatorTest.new(password: 'quxbazbarfoo', ssn: [])
+
+      validator.valid?.must_equal false
+      errors = validator.errors.for(:ssn)
+      errors.must_include Lotus::Validations::Error.new(:ssn, :size, 11, [])
+    end
+
     it "raises an error when the validator can't be coerced into an integer" do
       -> { SizeValidatorErrorTest.new(password: 'secret').valid? }.must_raise ArgumentError
     end


### PR DESCRIPTION
This Pull Request added the ability to ignore blank values for `size` predicate as well occurs for other predicates i.e. presence.

The only exceptional case down to Enumerable's implementations which if defined will be treated as value as it is. i.e:

```ruby
class AwesomeValidator
  include Lotus::Validations

  attribute :name, type: String, size: 8..10
  attribute :tags, type: Array,  size: 2..10
end

AwesomeValidator.new.valid? # < true
AwesomeValidator.new(name: '12345678', tags: '').valid? # < true
AwesomeValidator.new(tags: ['a', 'b']).valid? # < true
AwesomeValidator.new(name: nil).valid? # < true

AwesomeValidator.new(name: 'ooo').valid? # < false
AwesomeValidator.new(tags: []).valid? # < false
AwesomeValidator.new(name: 'abc', tags: []).valid? # < false
```

@solnic [has argued about](https://github.com/lotus/validations/issues/80#issuecomment-158085889) Conditional Validations and 'magical' validations/coercions which may introduce more complexity into this kind of issue. Maybe it worth more discussion later /cc @jodosha 

Closes #81